### PR TITLE
Fix 'Open in GitHub Codespaces' button on the install page

### DIFF
--- a/Material/2_Install-Juvix.md
+++ b/Material/2_Install-Juvix.md
@@ -5,7 +5,7 @@
   <a href="https://discord.gg/PfaaFVErHt"><img src="https://img.shields.io/discord/952881043520774194?logo=discord"/></a>
 </p>
 
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/anoma/juvix-workshop?quickstart=1)
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/anoma/applications-workshop?quickstart=1)
 
 ## Table of Contents
 


### PR DESCRIPTION
The 'Open in GitHub Codespaces' button currently launches the juvix-workshop codespace which is broken. Participants of the applications-workshop will want to use the applications-workshop codespace instead.